### PR TITLE
Fixes proposal

### DIFF
--- a/ByteBackpacker.podspec
+++ b/ByteBackpacker.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "ByteBackpacker"
-  s.version      = "1.2"
+  s.version      = "1.2.1"
   s.summary      = "ByteBackpacker is a small utility written in pure Swift to pack value types into a Byte array and unpack them back."
 
   # This description is used to generate tags and improve search results.
@@ -65,10 +65,10 @@ Pod::Spec.new do |s|
   # s.platform     = :ios, "5.0"
 
   #  When using multiple platforms
-  s.ios.deployment_target = "11.0"
-  s.osx.deployment_target = "10.13"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.11"
   s.watchos.deployment_target = "2.0"
-  s.tvos.deployment_target = "11.0"
+  s.tvos.deployment_target = "10.0"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/ByteBackpacker.xcodeproj/project.pbxproj
+++ b/ByteBackpacker.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		5F2408C81E0BE731004AF90F /* ByteBackpackerReferenceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ByteBackpackerReferenceTypeTests.swift; path = Tests/ByteBackpackerReferenceTypeTests.swift; sourceTree = "<group>"; };
 		5F2408C91E0BE731004AF90F /* ByteBackpackerValueTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ByteBackpackerValueTypeTests.swift; path = Tests/ByteBackpackerValueTypeTests.swift; sourceTree = "<group>"; };
 		5F2408CA1E0BE731004AF90F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
-		5F58BA641D956E8600C3B403 /* ByteBackpackerPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = ByteBackpackerPlayground.playground; sourceTree = "<group>"; };
+		5F58BA641D956E8600C3B403 /* ByteBackpackerPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = ByteBackpackerPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5F8561D11C415CA700316A22 /* ByteBackpacker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ByteBackpacker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F8561DB1C415CA700316A22 /* ByteBackpacker iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ByteBackpacker iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F8561F51C415D2400316A22 /* ByteBackpacker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ByteBackpacker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -396,8 +396,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = ByteBackpacker;
@@ -450,8 +450,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = ByteBackpacker;
 				SDKROOT = iphoneos;

--- a/Sources/ByteBackpacker.swift
+++ b/Sources/ByteBackpacker.swift
@@ -44,7 +44,7 @@ open class ByteBackpacker {
     /// - Returns: Value type of type `T`
     open class func unpack<T: Any>(_ valueByteArray: [Byte], toType type: T.Type, byteOrder: ByteOrder = .nativeByteOrder) -> T {
         assert(!(T.self is AnyClass), ByteBackpacker.referenceTypeErrorString)
-        let bytes = (byteOrder == .littleEndian) ? valueByteArray : valueByteArray.reversed()
+        let bytes = (byteOrder == ByteOrder.nativeByteOrder) ? valueByteArray : valueByteArray.reversed()
         return bytes.withUnsafeBufferPointer {
             return $0.baseAddress!.withMemoryRebound(to: T.self, capacity: 1) {
                 $0.pointee
@@ -65,7 +65,7 @@ open class ByteBackpacker {
         let valueByteArray = withUnsafePointer(to: &value) {
             Array(UnsafeBufferPointer(start: $0.withMemoryRebound(to: Byte.self, capacity: 1){$0}, count: MemoryLayout<T>.size))
         }
-        return (byteOrder == .littleEndian) ? valueByteArray : valueByteArray.reversed()
+        return (byteOrder == ByteOrder.nativeByteOrder) ? valueByteArray : valueByteArray.reversed()
     }
 }
 


### PR DESCRIPTION
Fixes:
- Extended deployment target to allow embedding in more projets
- Fixed the check for ByteOrdre in pack and unpack. This framework could be used in Mac or Linux projects with big-endian architectures. To reverse the array of Byte it is only necessary to check if the byteOrder: ByteOrder parameter is equal to ByteOrder.nativeByteOrder.